### PR TITLE
Ensure TypeScript build output stays out of source glob

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["./**/*.ts"],
+  "include": ["./**/*.ts", "!./dist/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- exclude the generated dist directory from the TypeScript include globs to avoid compiling build artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f6ef45289483289956f0bc2a8b63f8