### PR TITLE
chore: refresh lockfile and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@ node_modules/
 # Build output
 /dist/
 
+# Build caches
+/.turbo/
+/.cache/
+/.parcel-cache
+parcel-cache
+.eslintcache
+
 # Runtime data
 memory.json
 sessions.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "zod": "^3.22.4"
       },
       "bin": {
-        "lm-project-management-mcp": "index.js"
+        "lm-project-management-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^18.15.3",


### PR DESCRIPTION
## Summary
- refresh the generated package-lock.json so the CLI bin points at the built dist entry point
- expand the gitignore to cover common build caches while continuing to exclude runtime data

## Testing
- npm ci

------
https://chatgpt.com/codex/tasks/task_e_68f700ee0cf083288b2be86a0f4029da